### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Audio and video files will be transcribed upon ingestion.
 
 You can read more about the MCP Server use cases and features on our [blog](https://www.graphlit.com/blog/graphlit-mcp-server).
 
+<a href="https://glama.ai/mcp/servers/fscrivteod">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/fscrivteod/badge" alt="graphlit-mcp-server MCP server" />
+</a>
+
 ## Tools
 
 ### Retrieval


### PR DESCRIPTION
This PR adds a badge for the [graphlit-mcp-server](https://glama.ai/mcp/servers/fscrivteod) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fscrivteod">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/fscrivteod/badge" alt="graphlit-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.